### PR TITLE
Rewrite declarations

### DIFF
--- a/prax.c
+++ b/prax.c
@@ -344,7 +344,7 @@ void tkill(profile_t *process, int tid)
         printf("Thread kill failed :: id - %d\n", tid);
 }
 
-char *parse_status_fields(char *pid, char *field)
+static char *parse_status_fields(char *pid, char *field)
 {
     char *path;    
     CONSTRUCT_PATH(path, "%s%s%s", 3, PROC, pid, STATUS);

--- a/prax.h
+++ b/prax.h
@@ -183,10 +183,6 @@ void involuntary_context_switches(profile_t *process);
 // specifies the amount of virtual memory in use by a process.
 void virtual_mem(profile_t *process);
     
-// passing in a `char *` of a processes pid and a field e.g. ('uid', 'tgid', 'username')
-// will parse the proc fs the processes status file and return said field.
-char *parse_status_fields(char *pid, char *field);
-
 // Parses the stat file of the procfs.  By passing in a field number the 
 // parser function will return the field that is listed after the number of 
 // spaces equal to that number.


### PR DESCRIPTION
No need to expose the `/proc` parsing functions.
