### PR TITLE
Change `/proc/stat` function to be static

### DIFF
--- a/prax.c
+++ b/prax.c
@@ -385,19 +385,16 @@ free_path:
     return value;
 }
 
-char *parse_stat(char *pid, int field)
+static char *parse_stat(char *pid, int field)
 {
     char *fieldstr = NULL;
     
-    char *path = malloc(sizeof(char) * PATH_MAX + 1);
-    if (!path)
-        return NULL;
-
+    char path[PATH_MAX + 1];
     snprintf(path, PATH_MAX, "%s%s/stat", PROC, pid);
 
     FILE *fh = fopen(path, "r");
     if (!fh) 
-        goto free_path;
+        return NULL;
 
     size_t n = 0;
     char *line = NULL;
@@ -406,23 +403,18 @@ char *parse_stat(char *pid, int field)
 
     char *delim = " ";
     fieldstr = strtok(line, delim);
-    if (!fieldstr)
+    if (!fieldstr || field == 0)
         goto free_line;
 
-    int fieldno = 0;
-    while (fieldstr && fieldno < field) {
-        fieldno++;
+    for (int fieldno=0; fieldstr && fieldno < field; fieldno++)
         fieldstr = strtok(NULL, delim);
-    }
 
-    free_line:
+free_line:
         free(line);
-    close_fh:
+close_fh:
         fclose(fh);
-    free_path:
-        free(path);
 
-    return fieldstr;
+    return strdup(fieldstr);
 }
 
 void gettgid(profile_t *process)

--- a/prax.h
+++ b/prax.h
@@ -183,12 +183,6 @@ void involuntary_context_switches(profile_t *process);
 // specifies the amount of virtual memory in use by a process.
 void virtual_mem(profile_t *process);
     
-// Parses the stat file of the procfs.  By passing in a field number the 
-// parser function will return the field that is listed after the number of 
-// spaces equal to that number.
-char *parse_stat(char *pid, int field);
-
-
 #define MAXVAL 64
 
 // Initializer for the profile_t type.


### PR DESCRIPTION
There is no need to expose the `/proc` parser functions.
