### PR TITLE
Add procfs_base array-of-char field to cut down on mallocs

### DIFF
--- a/prax.h
+++ b/prax.h
@@ -52,11 +52,15 @@ typedef struct profile profile_t;
  *
  */
 
+#define PROCFS_MAX 32
+
 struct profile {
     uint32_t start_time;
     uint64_t vol_ctxt_swt;
     uint64_t invol_ctxt_swt;
     uint64_t vmem;
+    char procfs_base[PROCFS_MAX + 1];
+    size_t procfs_len;
     char *name;
     char *username;
     char ioprio[16];


### PR DESCRIPTION
Use the added `procfs_base` and `procfs_len` to cut down on the number of `snprintf` and `malloc` calls.

By keeping the return from the first `snprintf`, just index `procfs_base` with its length to build the next string when needed.